### PR TITLE
Exceptions

### DIFF
--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -19,11 +19,11 @@ use PGObject::Type::Registry;
 
 =head1 VERSION
 
-Version 2.3.2
+Version 2.4.0
 
 =cut
 
-our $VERSION = '2.3.2';
+our $VERSION = '2.4.0';
 
 =head1 SYNPOSIS
 

--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -13,7 +13,7 @@ use warnings;
 use Carp::Clan qr/^PGObject\b/;
 use Log::Any qw($log);
 use Memoize;
-
+use PGObject::Util::DBException;
 
 use PGObject::Type::Registry;
 
@@ -173,6 +173,9 @@ The number of arguments
 
 =cut
 
+sub _dup_func() { '42A01' }
+sub _no_func() { '26A01' }
+
 sub function_info {
     my ( $self, %args ) = @_;
     $args{funcschema} ||= 'public';
@@ -204,26 +207,34 @@ sub function_info {
         push @queryargs, $args{argschema};
     }
 
-    my $sth = $dbh->prepare($query) || die $!;
-    $sth->execute(@queryargs) || die $dbh->errstr . ": " . $query;
+    my $sth = $dbh->prepare($query) || die PGObject::Util::DBException->new(
+                                            $dbh, $query, @queryargs);
+    $sth->execute(@queryargs) || die PGObject::Util::DBException->new(
+                                            $dbh, $query, @queryargs);
     my $rows = $sth->rows;
     if ($rows > 1) {
         if ($args{argtype1}) {
-            croak $log->fatalf(
-                'Ambiguous criteria discovering function %s.%s (with first argument type %s)',
-                $args{funcschema}, $args{funcname}, $args{argtype1}
-                );
+            my $e = PGObject::Util::DBException->internal(_dup_func,
+                    sprintf('Ambiguous criteria discovering function %s.%s (with first argument type %s)',
+                        $args{funcschema}, $args{funcname}, $args{argtype1}
+                    ), $query, @queryargs);
+            croak $e;
         }
         else {
-            croak $log->fatalf(
-                'Ambiguous criteria discovering function %s.%s',
-                $args{funcschema}, $args{funcname}
-                );
+            my $e = PGObject::Util::DBException->internal(_dup_func,
+                    sprintf('Ambiguous criteria discovering function %s.%s',
+                        $args{funcschema}, $args{funcname}
+                    ), $query, @queryargs);
+            croak $e;
         }
     }
     elsif ($rows == 0) {
-        croak $log->fatalf( 'No such function: %s.%s',
-                            $args{funcschema}, $args{funcname} );
+        my $e = PGObject::Util::DBException->internal(_no_func,
+                    sprintf('No such function: %s.%s',
+                            $args{funcschema}, $args{funcname} ),
+                    $query, @queryargs);
+
+        croak $e;
     }
     my $ref = $sth->fetchrow_hashref('NAME_lc');
 
@@ -352,7 +363,8 @@ sub call_procedure {
          ORDER BY $order |;
     }
 
-    my $sth = $dbh->prepare($query) || die $!;
+    my $sth = $dbh->prepare($query) || die PGObject::Util::DBException(
+                                        $dbh, $query, @qargs);
 
     my $place = 1;
 
@@ -379,7 +391,7 @@ sub call_procedure {
         ++$place;
     }
 
-    $sth->execute() || die $dbh->errstr . ": " . $query;
+    $sth->execute() || die PGObject::Util::DBException->new($dbh, $query, @qargs);
 
     clear_info_cache() if $dbh->state eq '42883';    # (No Such Function)
 

--- a/lib/PGObject/Util/DBException.pm
+++ b/lib/PGObject/Util/DBException.pm
@@ -1,10 +1,10 @@
 =head1 NAME
 
-   PGObject::UTil::DBException -- Database Exceptions for PGObject
+   PGObject::Util::DBException -- Database Exceptions for PGObject
 
 =cut
 
-package PGObject::UTil::DBException;
+package PGObject::Util::DBException;
 
 =head1 VERSION
 
@@ -46,7 +46,7 @@ our $VERSION = '2.4.0';
 
 use strict;
 use warnings;
-use overload '""' => 'short_str';
+use overload '""' => 'short_string';
 use DBI;
 
 our $STRINGIFY_STACKTRACE = 1;
@@ -192,7 +192,7 @@ sub log_msg ($) {
     my $string = join "\n",
        "STATE $self->{state}, $self->{errstr}",
        "Query: $query",
-       "Args:" . (join ',', @{$self->{args}}),
+       "Args: " . (join ',', @{$self->{args}}),
        ($self->{trace} ? "Trace: $self->{trace}" : ());
     return $string;
 }

--- a/lib/PGObject/Util/DBException.pm
+++ b/lib/PGObject/Util/DBException.pm
@@ -1,0 +1,200 @@
+=head1 NAME
+
+   PGObject::UTil::DBException -- Database Exceptions for PGObject
+
+=cut
+
+package PGObject::UTil::DBException;
+
+=head1 VERSION
+
+   2.4.0
+
+=cut
+
+our $VERSION = '2.4.0';
+
+=head1 SYNOPSIS
+
+   use PGObject::Util::DBException;
+
+   $dbh->execute(@args) || die 
+       PGObject::Util::DBException->new($dbh, $query, @args);
+
+   # if you need something without dbh:
+
+   die PGObject::Util::DBException->internal($state, $string, $query, $args);
+
+   # if $dbh is undef, then we assume it is a connection error and ask DBI
+
+   # in a handler you can check
+   try {
+       some_db_func();
+   } catch {
+       if ($_->isa('PGObject::Util::DBException')){
+           if ($_->{state} eq '23505') {
+               warn "Duplicate data detected.";
+           }
+           log($_->log_msg);
+           die $_;
+       }
+       else {
+           die $_;
+       }
+
+=cut
+
+use strict;
+use warnings;
+use overload '""' => 'short_str';
+use DBI;
+
+our $STRINGIFY_STACKTRACE = 1;
+
+=head1 DESCRIPTION
+
+Database errors occur sometimes for a variety of reasons, including bugs,
+environmental, security, or user access problems, or a variety of other
+reasons.  For applications to appropriately handle database errors, it is often
+necessary to be able to act on categories of errors, while if we log errors for
+later analysis we want more information there.  For debugging (or even logging)
+we might even want to capture stack traces in order to try to understand where
+errors came from.  On the other hand, if we just want to display an error, we
+want to get an appropriate error string back.
+
+This class provides both options.  On one side, it provides data capture for
+logging, introspection, and analysis.  On the other it provides a short string
+form for display purposes.
+
+This is optimized around database errors.  It is not intended to be a general
+exception class outside the database layer.
+
+If C<Devel::StackTrace> is loaded we also capture a stack trace.
+
+=head2 Internal Error Codes
+
+In order to handle internal PGObject errors, we rely on the fact that no
+current SQL subclasses contian the letter 'A' which we will use to mean
+Application.  We therefore take existing SQLState classes and use AXX
+(currently only A01 is used currently) to handle these errors.
+
+=over
+
+=item 26A01
+
+Function not found.  No function with the discovery criteria set was found.
+
+=item 42A01
+
+Function not unique.  Multiple functions for the discovery criteria were
+found.
+
+=back
+
+=head2 Stack Traces
+
+If C<Devel::StackTrace> is loaded, we will capture stack traces starting at the
+exception class call itself.
+
+In order to be unobtrusive, these are stringified by default.  This is to avoid
+problems of reference counting and lifecycle that can happen when capturing
+tracing information,  If you want to capture the whole stack trace without
+stringification, then you can set the following variable to 0:
+C<PGObject::Util::DBException::STRINGIFY_STACKTRACE>.  Naturally this is best
+done using the C<local> keyword.
+
+Note that non-stringified stacktraces are B<not> weakened and this can cause
+things like database handles to persist for longer than they ordinarily would.
+For this reason, turning off stringification is best reserved for cases where
+it is absolutely required.
+
+=head1 CONSTRUCTORS
+
+All constructors are called exclusively via C<$class->method> syntax.
+
+=head2 internal($state, $errstr, $query, $args);
+
+Used for internal application errors.  Creates an exception of this type with
+these attributes.  This is useful for appication errors within the PGObject
+framework.
+
+=cut
+
+sub internal ($$$$@) {
+    my ($class, $state, $errstr, $query, @args) = @_;
+    my $self = {
+        state  => $state,
+        errstr => $errstr,
+        query  => $query,
+        args   => \@args,
+        trace  => undef,
+    };
+    if (scalar grep { $_ eq 'Devel/StackTrace.pm' } keys %INC){
+        $self->{trace} = $STRINGIFY_STACKTRACE ? Devel::StackTrace->new->as_string
+                                               : Devel::StackTrace->new;
+    }
+    bless $self, $class;
+}
+
+
+=head2 new($dbh, $query, @args)
+
+This creates a new exception object.  The SQL State is taken from the C<$dbh>
+database handle if it is defined, and the C<DBI> module if it is not.
+
+=cut
+
+sub new ($$$@) {
+    my ($class, $dbh, $query, @args) = @_;
+    return $class->internal(
+        (defined $dbh ? $dbh->state  : $DBI::state  ),
+        (defined $dbh ? $dbh->errstr : $DBI::errstr ),
+        $query, @args
+    );
+}
+
+=head1 Stringificatoin
+
+This module provides two methods for string representation.  The first, for
+human-focused error messages also overloads stringification generally.  The
+second is primarily intended for logging purposes.
+
+=head2 short_string
+
+The C<short_string> method returns a short string of C<state: errstr> for human
+presentation.
+
+=cut
+
+sub short_string ($) {
+    my $self = shift;
+    return "$self->{state}: $self->{errstr}";
+}
+
+=head2 log_msg
+
+As its name suggests, C<log_msg> aimes to provide full infomation for logging
+purposes.
+
+The format here is:
+
+  STATE state, errstr
+  Query: query
+  Args: joun(',', @args)
+  Trace: Stacktrace
+
+
+=cut
+
+sub log_msg ($) {
+    my $self = shift;
+    my $query = ( $self->{query} // 'None' );
+    my $string = join "\n",
+       "STATE $self->{state}, $self->{errstr}",
+       "Query: $query",
+       "Args:" . (join ',', @{$self->{args}}),
+       ($self->{trace} ? "Trace: $self->{trace}" : ());
+    return $string;
+}
+
+1;

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -2,10 +2,11 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 BEGIN {
     use_ok( 'PGObject' ) || print "Bail out!\n";
+    use_ok( 'PGObject::Util::DBException' ) || print "Bail out!\n";
 }
 
 diag( "Testing PGObject $PGObject::VERSION, Perl $], $^X" );

--- a/t/03-legacy_registry.t
+++ b/t/03-legacy_registry.t
@@ -12,6 +12,8 @@ use Test::More tests => 14;
 use PGObject;
 use Test::Exception;
 
+$SIG{__WARN__} = sub {};
+
 
 lives_ok(sub {PGObject->register_type(pg_type => 'foo', perl_class => 'Foo') },      "Basic type registration");
 lives_ok(sub {PGObject->register_type(pg_type => 'foo', perl_class => 'Foo')},

--- a/t/03-legacy_registry.t
+++ b/t/03-legacy_registry.t
@@ -12,7 +12,7 @@ use Test::More tests => 14;
 use PGObject;
 use Test::Exception;
 
-$SIG{__WARN__} = sub {};
+$SIG{__WARN__} = sub {}; # all these warn as deprecated which is the point
 
 
 lives_ok(sub {PGObject->register_type(pg_type => 'foo', perl_class => 'Foo') },      "Basic type registration");

--- a/t/04-registered_types.t
+++ b/t/04-registered_types.t
@@ -6,6 +6,8 @@ use PGObject 'test1', 'test2';
 
 ok(PGObject::Type::Registry->inspect('test1'), 'test1 registry exists');
 ok(PGObject::Type::Registry->inspect('test2'), 'test2 registry exists');
+{
+local $SIG{__WARN__} = sub {}; # silence output on deprecated methods
 lives_ok {PGObject->new_registry('test1') } 'New registry 1 recreation lives';
 lives_ok {PGObject->new_registry('blank') } 'New registry blank created';
 lives_ok {PGObject->new_registry('test2') } 'New registry 2 recreation lives';
@@ -14,7 +16,7 @@ is(PGObject->register_type(pg_type => 'int4', perl_class => 'test1'), 1,
 is(PGObject->register_type(
         pg_type => 'int4', perl_class => 'test2', registry => 'test1'), 1,
        "Basic type registration");
-
+}
 SKIP: {
     skip 'No database connection', 11 unless $ENV{DB_TESTING};
 

--- a/t/05-exception.t
+++ b/t/05-exception.t
@@ -1,0 +1,19 @@
+use Test::More tests => 9;
+use PGObject::Util::DBException;
+use DBI;
+
+# the internal constructor
+ok(my $e = PGObject::Util::DBException->internal(
+        'ABCDE', 'Something silly', 'What are we doing here?',
+        1,2,'132', 'FooBar'));
+is($e->{state}, 'ABCDE', 'Got back the correct state');
+is($e->{errstr}, 'Something silly', 'Errstr works');
+is($e->{query}, 'What are we doing here?', 'Got our query back').
+is_deeply($e->{args}, [1,2,'132', 'FooBar'], 'Got back the args');
+is($e->{trace}, undef, 'No stack trace');
+is("$e", 'ABCDE: Something silly', 'Stringification works properly');
+is($e->short_string, 'ABCDE: Something silly', 'Stringification works properly 2');
+is($e->log_msg, 
+    "STATE ABCDE, Something silly
+Query: What are we doing here?
+Args: 1,2,132,FooBar", 'Got the log message');


### PR DESCRIPTION
This adds an exception class with a number of interesting features, and this allows for machine introspection for reasons of database query.

The exception is a simple blessed hashref with fields for SQL State, errror string, query, args, and a stacktrace.  The stack trace is gathered of Devel::StackTrace is loaded.

Fixes #24 